### PR TITLE
feat: Add PyPI publishing and bump version to 0.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,87 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to Test PyPI first'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build wheel
+        
+    - name: Build distribution
+      run: python -m build
+      
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+  test-pypi:
+    name: Publish to Test PyPI
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.test_pypi == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/project/netbox-cable-labels/
+    permissions:
+      id-token: write  # IMPORTANT: for trusted publishing
+      
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        
+  pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'release' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/netbox-cable-labels/
+    permissions:
+      id-token: write  # IMPORTANT: for trusted publishing
+      
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,13 @@
 include CONTRIBUTING.md
 include LICENSE
 include README.md
+include pyproject.toml
 
-recursive-include tests *
+recursive-include netbox_cable_labels *.py
+recursive-include netbox_cable_labels/management *
+recursive-include netbox_cable_labels/tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-
-recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+recursive-exclude * .gitignore
+prune testing
+prune docs

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugin for netbox that allows the automatic generation of the label field conten
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
-|     4.x        |      0.0.4     |
+|     4.x        |      0.1.x     |
 
 
 ## Installing
@@ -16,7 +16,13 @@ Plugin for netbox that allows the automatic generation of the label field conten
 For adding to a NetBox Docker setup see
 [the general instructions for using netbox-docker with plugins](https://github.com/netbox-community/netbox-docker/wiki/Using-Netbox-Plugins).
 
-While this is still in development and not yet on pypi you can install with pip:
+### Install from PyPI
+
+```bash
+pip install netbox-cable-labels
+```
+
+### Install from GitHub
 
 ```bash
 pip install git+https://github.com/jsenecal/netbox-cable-labels
@@ -25,7 +31,7 @@ pip install git+https://github.com/jsenecal/netbox-cable-labels
 or by adding to your `local_requirements.txt` or `plugin_requirements.txt` (netbox-docker):
 
 ```bash
-git+https://github.com/jsenecal/netbox-cable-labels
+netbox-cable-labels
 ```
 
 Enable the plugin in `/opt/netbox/netbox/netbox/configuration.py`,

--- a/netbox_cable_labels/__init__.py
+++ b/netbox_cable_labels/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = "Jonathan Senecal"
 __email__ = "contact@jonathansenecal.com"
-__version__ = "0.0.4"
+__version__ = "0.1.0"
 
 from netbox.plugins import PluginConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "netbox-cable-labels"
+dynamic = ["version"]
+description = "NetBox plugin for automatic cable label generation"
+readme = "README.md"
+authors = [
+    {name = "Jonathan Senecal", email = "contact@jonathansenecal.com"}
+]
+license = "Apache-2.0"
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Plugins",
+    "Framework :: Django",
+    "Intended Audience :: System Administrators",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: System :: Networking",
+]
+keywords = ["netbox", "netbox-plugin", "cable-management", "labeling"]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/jsenecal/netbox-cable-labels"
+Repository = "https://github.com/jsenecal/netbox-cable-labels.git"
+Issues = "https://github.com/jsenecal/netbox-cable-labels/issues"
+
+[tool.setuptools.packages.find]
+include = ["netbox_cable_labels*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "netbox_cable_labels.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,5 +35,3 @@ python =
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
- Add GitHub Actions workflow for automated PyPI publishing
- Create pyproject.toml with modern packaging configuration
- Update MANIFEST.in for proper package distribution
- Remove deprecated universal wheel configuration
- Bump version to 0.1.0 for first PyPI release
- Update README with PyPI installation instructions