### PR TITLE
feat: Add TIA-606-C template examples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ By default, the plugin copies the cable `id` in the label, prefixed with the pou
 "#{{cable.pk}}"
 ```
 
+### Template Examples
+
+See [TEMPLATES.md](TEMPLATES.md) for comprehensive template examples including TIA-606-C compliant formats and various labeling scenarios.
+
 ## Management command
 
 Using `manage.py`, you can run the command `generate_labels` to automatically generate labels on cables that do not already have one set, based on the configured template.

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -1,0 +1,135 @@
+# Cable Label Templates
+
+This document provides example templates for the netbox-cable-labels plugin, including TIA-606-C compliant formats.
+
+## TIA-606-C Standard Templates
+
+The TIA-606-C standard specifies that cable labels should include termination points and pathway information. The general format is:
+**Near End - Far End / Media Type / Identifier**
+
+### Basic TIA-606-C Template
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_cable_labels": {
+        "label_template": "{{cable.a_terminations.first().device.site.name}}-{{cable.a_terminations.first().device.name}}/{{cable.b_terminations.first().device.site.name}}-{{cable.b_terminations.first().device.name}}/{{cable.type|default('CAT6')}}/{{cable.pk}}"
+    }
+}
+```
+
+### Rack-Based Template
+Includes rack location and device position:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_cable_labels": {
+        "label_template": "{{cable.a_terminations.first().device.rack.name}}-{{cable.a_terminations.first().device.position}}{{cable.a_terminations.first().device.face|first|upper}}/{{cable.b_terminations.first().device.rack.name}}-{{cable.b_terminations.first().device.position}}{{cable.b_terminations.first().device.face|first|upper}}/{{cable.type|default('UTP')}}/C{{'{:05d}'.format(cable.pk)}}"
+    }
+}
+```
+Example output: `R1A-42F/R2B-10R/CAT6A/C00123`
+
+### Detailed Location Template
+Includes building/location, rack, and port information:
+
+```python
+PLUGINS_CONFIG = {
+    "netbox_cable_labels": {
+        "label_template": "{%- set a_term = cable.a_terminations.first() -%}{%- set b_term = cable.b_terminations.first() -%}{{a_term.device.site.name|upper}}-{{a_term.device.rack.name ~ ':' ~ a_term.device.name}}-{{a_term.name}}/{{b_term.device.site.name|upper}}-{{b_term.device.rack.name ~ ':' ~ b_term.device.name}}-{{b_term.name}}{%- if cable.length %}/{{cable.length}}m{% endif %}/ID{{'{:06d}'.format(cable.pk)}}"
+    }
+}
+```
+Example output: `NYC-R1A:SW01-gi1/0/1/NYC-R2B:SW02-gi1/0/1/10m/ID000123`
+
+Note: The `~` operator is used for string concatenation in Jinja2 when special characters like `:` need to be included.
+
+## Data Center Templates
+
+### Simple DC Template
+```python
+"label_template": "{{cable.a_terminations.first().device.name}}-{{cable.a_terminations.first().name}} to {{cable.b_terminations.first().device.name}}-{{cable.b_terminations.first().name}}"
+```
+Example output: `SW01-eth1/1 to SW02-eth1/1`
+
+### Patch Panel Template
+```python
+"label_template": "{% set a = cable.a_terminations.first() %}{% set b = cable.b_terminations.first() %}PP{{a.device.rack.name}}-{{a.name}} / PP{{b.device.rack.name}}-{{b.name}} / {{cable.color|default('BLU')|upper|truncate(3,True,'')}}"
+```
+Example output: `PPR1A-24 / PPR2B-12 / BLU`
+
+## Network Infrastructure Templates
+
+### Structured Cabling Template
+```python
+"label_template": "{{cable.a_terminations.first().device.location.name|default(cable.a_terminations.first().device.site.name)}}.{{cable.a_terminations.first().device.name}}.{{cable.a_terminations.first().name}}--{{cable.b_terminations.first().device.location.name|default(cable.b_terminations.first().device.site.name)}}.{{cable.b_terminations.first().device.name}}.{{cable.b_terminations.first().name}}"
+```
+Example output: `Floor2.IDF2.SW01.gi1--Floor1.MDF.CORE01.te1/1/1`
+
+### Fiber Optic Template
+```python
+"label_template": "{% if 'fiber' in cable.type|lower or 'sm' in cable.type|lower or 'mm' in cable.type|lower %}FO-{% endif %}{{cable.a_terminations.first().device.rack.name}}-{{cable.a_terminations.first().name}}/{{cable.b_terminations.first().device.rack.name}}-{{cable.b_terminations.first().name}}/{{cable.type|upper}}/{{cable.color|default('YEL')|upper}}"
+```
+Example output: `FO-R1A-LC1/R2B-LC1/SM-OS2/YEL`
+
+## Available Cable Object Attributes
+
+Common attributes available in templates:
+
+- `cable.pk` - Unique cable ID
+- `cable.type` - Cable type (CAT6, CAT6A, SM-OS2, etc.)
+- `cable.status` - Cable status
+- `cable.color` - Cable color
+- `cable.length` - Cable length
+- `cable.length_unit` - Length unit
+- `cable.description` - Cable description
+- `cable.comments` - Cable comments
+- `cable.tags` - Cable tags
+
+For terminations (using `cable.a_terminations.first()` or `cable.b_terminations.first()`):
+- `.device` - Connected device
+- `.device.name` - Device name
+- `.device.site` - Device site
+- `.device.rack` - Device rack
+- `.device.location` - Device location
+- `.device.position` - Rack position
+- `.device.face` - Rack face (front/rear)
+- `.name` - Interface/port name
+
+## Template Functions and Filters
+
+Jinja2 filters that can be used:
+- `|upper` - Convert to uppercase
+- `|lower` - Convert to lowercase
+- `|default('value')` - Provide default value
+- `|truncate(n,True,'')` - Truncate to n characters
+- `|first` - Get first character
+- `|stringformat:'05d'` - Format number with padding
+
+## Testing Templates
+
+Before deploying a template, test it using Django shell:
+
+```python
+from dcim.models import Cable
+from netbox_cable_labels.utils import render_label
+
+# Get a sample cable
+cable = Cable.objects.first()
+
+# Test your template
+from jinja2 import Environment, BaseLoader
+env = Environment(loader=BaseLoader)
+template_string = "Your template here"
+template = env.from_string(template_string)
+result = template.render(cable=cable)
+print(result)
+```
+
+## Best Practices
+
+1. **Keep labels concise** - Most label makers have character limits
+2. **Use consistent formatting** - Uppercase for static text, consistent separators
+3. **Include unique identifiers** - Always include cable.pk or another unique ID
+4. **Consider label maker constraints** - Some characters may not print well
+5. **Test with edge cases** - Cables without racks, locations, or complete terminations
+6. **Use defaults** - Provide fallback values for optional fields

--- a/netbox_cable_labels/tests/test_tia_templates.py
+++ b/netbox_cable_labels/tests/test_tia_templates.py
@@ -1,0 +1,248 @@
+"""Test TIA-606-C compliant template rendering."""
+
+from django.test import TestCase, override_settings
+from unittest.mock import Mock, MagicMock
+from netbox_cable_labels.utils import render_label
+
+
+class TIA606CTemplateTestCase(TestCase):
+    """Test various TIA-606-C compliant templates."""
+
+    def setUp(self):
+        """Set up mock cable object with full NetBox-like structure."""
+        # Create mock site objects
+        self.mock_site_a = Mock()
+        self.mock_site_a.name = "NYC"
+        
+        self.mock_site_b = Mock()
+        self.mock_site_b.name = "NYC"
+        
+        # Create mock location objects
+        self.mock_location_a = Mock()
+        self.mock_location_a.name = "Floor2"
+        
+        self.mock_location_b = Mock()
+        self.mock_location_b.name = "Floor1"
+        
+        # Create mock rack objects
+        self.mock_rack_a = Mock()
+        self.mock_rack_a.name = "R1A"
+        
+        self.mock_rack_b = Mock()
+        self.mock_rack_b.name = "R2B"
+        
+        # Create mock manufacturer
+        self.mock_manufacturer_a = Mock()
+        self.mock_manufacturer_a.name = "Cisco"
+        
+        self.mock_manufacturer_b = Mock()
+        self.mock_manufacturer_b.name = "HPE"
+        
+        # Create mock device type
+        self.mock_device_type_a = Mock()
+        self.mock_device_type_a.manufacturer = self.mock_manufacturer_a
+        
+        self.mock_device_type_b = Mock()
+        self.mock_device_type_b.manufacturer = self.mock_manufacturer_b
+        
+        # Create mock device objects
+        self.mock_device_a = Mock()
+        self.mock_device_a.name = "SW01"
+        self.mock_device_a.site = self.mock_site_a
+        self.mock_device_a.location = self.mock_location_a
+        self.mock_device_a.rack = self.mock_rack_a
+        self.mock_device_a.position = 42
+        self.mock_device_a.face = "front"
+        self.mock_device_a.device_type = self.mock_device_type_a
+        
+        self.mock_device_b = Mock()
+        self.mock_device_b.name = "SW02"
+        self.mock_device_b.site = self.mock_site_b
+        self.mock_device_b.location = self.mock_location_b
+        self.mock_device_b.rack = self.mock_rack_b
+        self.mock_device_b.position = 10
+        self.mock_device_b.face = "rear"
+        self.mock_device_b.device_type = self.mock_device_type_b
+        
+        # Create mock termination objects
+        self.mock_termination_a = Mock()
+        self.mock_termination_a.device = self.mock_device_a
+        self.mock_termination_a.name = "gi1/0/1"
+        
+        self.mock_termination_b = Mock()
+        self.mock_termination_b.device = self.mock_device_b
+        self.mock_termination_b.name = "eth1/1"
+        
+        # Create mock terminations manager
+        self.mock_a_terminations = Mock()
+        self.mock_a_terminations.first.return_value = self.mock_termination_a
+        
+        self.mock_b_terminations = Mock()
+        self.mock_b_terminations.first.return_value = self.mock_termination_b
+        
+        # Create mock cable object
+        self.mock_cable = Mock()
+        self.mock_cable.pk = 123
+        self.mock_cable.type = "CAT6A"
+        self.mock_cable.status = "connected"
+        self.mock_cable.color = "blue"
+        self.mock_cable.length = 10
+        self.mock_cable.length_unit = "m"
+        self.mock_cable.a_terminations = self.mock_a_terminations
+        self.mock_cable.b_terminations = self.mock_b_terminations
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{{cable.a_terminations.first().device.rack.name}}-{{cable.a_terminations.first().device.position}}{{cable.a_terminations.first().device.face|first|upper}}/{{cable.b_terminations.first().device.rack.name}}-{{cable.b_terminations.first().device.position}}{{cable.b_terminations.first().device.face|first|upper}}/{{cable.type|default('UTP')}}/C{{'{:05d}'.format(cable.pk)}}"
+            }
+        }
+    )
+    def test_basic_tia_606c_template(self):
+        """Test basic TIA-606-C rack-based template."""
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "R1A-42F/R2B-10R/CAT6A/C00123")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{{cable.a_terminations.first().device.site.name}}-{{cable.a_terminations.first().device.name}}/{{cable.b_terminations.first().device.site.name}}-{{cable.b_terminations.first().device.name}}/{{cable.type|default('CAT6')}}/{{cable.pk}}"
+            }
+        }
+    )
+    def test_site_based_template(self):
+        """Test site-based TIA-606-C template."""
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "NYC-SW01/NYC-SW02/CAT6A/123")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{%- set a_term = cable.a_terminations.first() -%}{%- set b_term = cable.b_terminations.first() -%}{{a_term.device.site.name|upper}}-{{a_term.device.rack.name ~ ':' ~ a_term.device.name}}-{{a_term.name}}/{{b_term.device.site.name|upper}}-{{b_term.device.rack.name ~ ':' ~ b_term.device.name}}-{{b_term.name}}{%- if cable.length %}/{{cable.length}}m{% endif %}/ID{{'{:06d}'.format(cable.pk)}}"
+            }
+        }
+    )
+    def test_detailed_location_template(self):
+        """Test detailed location template with port information."""
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "NYC-R1A:SW01-gi1/0/1/NYC-R2B:SW02-eth1/1/10m/ID000123")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{{cable.a_terminations.first().device.location.name}}.{{cable.a_terminations.first().device.rack.name}}.{{cable.a_terminations.first().name}}/{{cable.b_terminations.first().device.location.name}}.{{cable.b_terminations.first().device.rack.name}}.{{cable.b_terminations.first().name}}/{{cable.type}}/{{cable.pk}}"
+            }
+        }
+    )
+    def test_building_floor_room_template(self):
+        """Test building/floor/room based template."""
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "Floor2.R1A.gi1/0/1/Floor1.R2B.eth1/1/CAT6A/123")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{% set a = cable.a_terminations.first() %}{% set b = cable.b_terminations.first() %}{{a.device.device_type.manufacturer.name[:3]|upper}}{{a.device.name}}-{{a.name}}/{{b.device.device_type.manufacturer.name[:3]|upper}}{{b.device.name}}-{{b.name}}/{{cable.type|default('CAT6')}}/{{cable.color[:3]|upper if cable.color else 'BLU'}}"
+            }
+        }
+    )
+    def test_patch_panel_focused_template(self):
+        """Test patch panel focused template with manufacturer abbreviation."""
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "CISSW01-gi1/0/1/HPESW02-eth1/1/CAT6A/BLU")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{{cable.a_terminations.first().device.name}}-{{cable.a_terminations.first().name}} to {{cable.b_terminations.first().device.name}}-{{cable.b_terminations.first().name}}"
+            }
+        }
+    )
+    def test_simple_descriptive_template(self):
+        """Test simple descriptive template."""
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "SW01-gi1/0/1 to SW02-eth1/1")
+
+    def test_template_with_missing_attributes(self):
+        """Test template handling when some attributes are missing."""
+        # Create cable with minimal data
+        mock_device_minimal = Mock()
+        mock_device_minimal.name = "Device1"
+        mock_device_minimal.site = None
+        mock_device_minimal.rack = None
+        mock_device_minimal.location = None
+        
+        mock_termination_minimal = Mock()
+        mock_termination_minimal.device = mock_device_minimal
+        mock_termination_minimal.name = "port1"
+        
+        mock_terminations = Mock()
+        mock_terminations.first.return_value = mock_termination_minimal
+        
+        mock_cable_minimal = Mock()
+        mock_cable_minimal.pk = 456
+        mock_cable_minimal.type = None
+        mock_cable_minimal.color = None
+        mock_cable_minimal.length = None
+        mock_cable_minimal.a_terminations = mock_terminations
+        mock_cable_minimal.b_terminations = mock_terminations
+        
+        with override_settings(
+            PLUGINS_CONFIG={
+                "netbox_cable_labels": {
+                    "label_template": "{{cable.a_terminations.first().device.name}}/{{cable.b_terminations.first().device.name}}/{{cable.type if cable.type else 'UNK'}}/{{cable.pk}}"
+                }
+            }
+        ):
+            label = render_label(mock_cable_minimal)
+            self.assertEqual(label, "Device1/Device1/UNK/456")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{% if 'fiber' in cable.type|lower or 'sm' in cable.type|lower %}FO-{% endif %}{{cable.a_terminations.first().device.rack.name}}-{{cable.a_terminations.first().name}}/{{cable.b_terminations.first().device.rack.name}}-{{cable.b_terminations.first().name}}/{{cable.type|upper}}"
+            }
+        }
+    )
+    def test_fiber_optic_template(self):
+        """Test fiber optic cable template with conditional prefix."""
+        # Test with fiber cable
+        self.mock_cable.type = "SM-OS2"
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "FO-R1A-gi1/0/1/R2B-eth1/1/SM-OS2")
+        
+        # Test with copper cable
+        self.mock_cable.type = "CAT6A"
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "R1A-gi1/0/1/R2B-eth1/1/CAT6A")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{{cable.a_terminations.first().device.rack.name}}-{{'{:02d}'.format(cable.a_terminations.first().device.position)}}/{{cable.b_terminations.first().device.rack.name}}-{{'{:02d}'.format(cable.b_terminations.first().device.position)}}"
+            }
+        }
+    )
+    def test_position_formatting(self):
+        """Test position formatting with zero padding."""
+        self.mock_device_b.position = 5
+        label = render_label(self.mock_cable)
+        self.assertEqual(label, "R1A-42/R2B-05")
+
+    @override_settings(
+        PLUGINS_CONFIG={
+            "netbox_cable_labels": {
+                "label_template": "{{cable.a_terminations.first().device.location.name|default(cable.a_terminations.first().device.site.name)}}.{{cable.a_terminations.first().device.name}}"
+            }
+        }
+    )
+    def test_fallback_values(self):
+        """Test template with fallback values using default filter."""
+        # With location
+        label = render_label(self.mock_cable)
+        self.assertIn("Floor2.SW01", label)
+        
+        # Without location (should fall back to site)
+        self.mock_device_a.location = None
+        label = render_label(self.mock_cable)
+        self.assertIn("NYC.SW01", label)


### PR DESCRIPTION
- Add comprehensive TEMPLATES.md with TIA-606-C compliant examples
- Add test cases for various TIA-606-C template formats
- Include templates for rack-based, site-based, and detailed labeling
- Test edge cases with missing attributes and fallback values